### PR TITLE
Python version and local config update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ARG DEV=0
 
 RUN apt update && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt install software-properties-common make gcc curl python3.7 python3-pip -y && \
-    python3.7 -m pip install pip
+    apt install software-properties-common make gcc curl python3 python3-pip -y && \
+    python3 -m pip install pip
 
 WORKDIR /circulation-import
 COPY poetry.lock pyproject.toml Makefile README.md /circulation-import/
@@ -24,4 +24,4 @@ RUN make install BIN=/usr/local/bin/ DEV=$DEV
 
 COPY . /circulation-import
 
-ENTRYPOINT ["python3.7", "-m", "circulation_import"]
+ENTRYPOINT ["python3", "-m", "circulation_import"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: config install lint mypy full-lint test build publish clean all ci
+HONY: config install lint mypy full-lint test build publish clean all ci
 .DEFAULT_GOAL := all
 
 all: install lint mypy test build
@@ -26,8 +26,8 @@ config:
 
 prepare:
 	if [ "${DEV}" = "1" ]; then virtualenv ${VIRTUAL_ENV}; fi
-	python3.7 -m pip install pip==${PIP_VERSION}
-	python3.7 -m pip install poetry==${POETRY_VERSION}
+	python3 -m pip install pip==${PIP_VERSION}
+	python3 -m pip install poetry==${POETRY_VERSION}
 
 install:
 	make prepare

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HONY: config install lint mypy full-lint test build publish clean all ci
+.PHONY: config install lint mypy full-lint test build publish clean all ci
 .DEFAULT_GOAL := all
 
 all: install lint mypy test build

--- a/configuration/server-configuration.local.yml
+++ b/configuration/server-configuration.local.yml
@@ -1,14 +1,14 @@
 !ServerConfiguration
 hashing_algorithm: SHA-1
-upload_directory: ../../upload
+upload_directory: ./upload
 
 database_configuration: !DatabaseConfiguration
   driver: sqlite
-  database: ../../storage/server.db
+  database: ./storage/server.db
   echo: true
 
 importer_configuration: !ImporterConfiguration
-  import_script_command: bin/directory_import
+  import_script_command: source /var/www/circulation/env/bin/activate && /var/www/circulation/bin/directory_import
   collection_name: LCP
   collection_type: LCP
   data_source_name: data_source_1


### PR DESCRIPTION
## Description

Set python version to `3` instead of `3.7` in `Dockerfile` and `Makefile` and updated local configuration.

## Motivation and Context

Debian removed some packages from the core Python packages (`distutils`) so it would error out with `python3.7` so I set it to only use `python3`. See: [link](https://askubuntu.com/questions/1239829/modulenotfounderror-no-module-named-distutils-util/1260519#1260519)

Also, there are some smaller local config changes.

## How Has This Been Tested?
Docker images built and ran the import locally.
